### PR TITLE
fix memory leak on yaml set input string

### DIFF
--- a/yaml/yamlc-inline.c
+++ b/yaml/yamlc-inline.c
@@ -1,4 +1,5 @@
 #include <kklib.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <yaml.h>
 
@@ -86,19 +87,24 @@ static kk_unit_t kk_yaml_yamlc_set_input_file(kk_box_t bparser, kk_box_t bfile, 
   return kk_Unit;
 }
 
-static kk_unit_t kk_yaml_c_set_input_string(kk_box_t bparser, kk_string_t yaml, kk_context_t *ctx) {
+static kk_unit_t kk_yaml_c_set_input_string(kk_box_t bparser, kk_addr_t yaml, kk_ssize_t len,
+                                            kk_context_t *ctx) {
   yaml_parser_t *parser = (yaml_parser_t *) kk_cptr_unbox_borrowed(bparser, ctx);
-  kk_ssize_t len;
-  const u_int8_t *cyaml = kk_string_buf_borrow(yaml, &len, ctx);
-  yaml_parser_set_input_string(parser, cyaml, len);
-
+  yaml_parser_set_input_string(parser, (uint8_t *) yaml, len);
   // kk_string_drop(yaml, ctx);
   kk_box_drop(bparser, ctx);
 
   return kk_Unit;
 }
 
-kk_box_t kk_yaml_yamlc_open_file(kk_string_t path, kk_context_t *ctx) {
+static kk_box_t kk_yaml_yamlc_with_c_string(kk_string_t s, kk_function_t f, kk_context_t *_ctx) {
+  kk_ssize_t len;
+  kk_addr_t cptr = (kk_addr_t) kk_string_cbuf_borrow(s, &len, kk_context());
+  return kk_function_call(kk_box_t, (kk_function_t, kk_addr_t, kk_ssize_t, kk_context_t *), f,
+                          (f, cptr, len, kk_context()), kk_context());
+}
+
+static kk_box_t kk_yaml_yamlc_open_file(kk_string_t path, kk_context_t *ctx) {
   kk_ssize_t len;
   const char *cpat = kk_string_cbuf_borrow(path, &len, ctx);
 
@@ -108,7 +114,7 @@ kk_box_t kk_yaml_yamlc_open_file(kk_string_t path, kk_context_t *ctx) {
   return kk_cptr_box(file, ctx);
 }
 
-kk_box_t kk_yaml_yamlc_open_write_file(kk_string_t path, kk_context_t *ctx) {
+static kk_box_t kk_yaml_yamlc_open_write_file(kk_string_t path, kk_context_t *ctx) {
   kk_ssize_t len;
   const char *cpat = kk_string_cbuf_borrow(path, &len, ctx);
 

--- a/yaml/yamlc.kk
+++ b/yaml/yamlc.kk
@@ -280,7 +280,7 @@ extern yaml-close-file(file: any): ()
 extern yaml-set-input-file(parser: libyaml-parser, file: any): ()
   c "kk_yaml_yamlc_set_input_file"
 
-extern yaml-set-input-string(parser: libyaml-parser, yaml: string): ()
+extern yaml-set-input-string(parser: libyaml-parser, yaml: intptr_t, len: int64): ()
   c "kk_yaml_c_set_input_string"
 
 extern yaml-parser-parse-one(parser: libyaml-parser): <div> either<yaml-parse-error, libyaml-event>
@@ -354,6 +354,9 @@ extern yaml-get-mapping-start-implicit(^ev: libyaml-event): int32
 
 extern yaml-get-event-document-end-implicit(^ev: libyaml-event): int32
   c "kk_yaml_yamlc_get_event_document_end_implicit"
+
+extern yaml-with-c-string(^s: string, f: (intptr_t, int64) -> e a): e a
+  c "kk_yaml_yamlc_with_c_string"
 
 // get event
 fun get-event(ev: libyaml-event): maybe<marked-event>
@@ -445,9 +448,10 @@ pub fun decode-file(path: path): <div,yaml-stream<marked-event>,exn> ()
 
 
 pub fun decode-string(yaml: string): <div,yaml-stream<marked-event>,exn> ()
-  val parser = create-yaml-parser()
-  parser.yaml-set-input-string(yaml)
-  parser.stream-event
+  yaml.yaml-with-c-string fn(addr, len)
+    val parser = create-yaml-parser()
+    parser.yaml-set-input-string(addr, len)
+    parser.stream-event
 
 
 pub fun print-stream-event(action: () -> <yaml-stream<marked-event>,console,exn|e> a): <console,exn|e> a
@@ -463,10 +467,10 @@ pub fun collect-stream-event(action: () -> <yaml-stream<marked-event>,exn|e> ())
 
   action()
 
-pub alias libyaml-emitter = any
+alias libyaml-emitter = any
 
 // our custom buffer
-pub alias yamlc-buffer = any
+alias yamlc-buffer = any
 
 extern kk-emitter-create(): libyaml-emitter
   c "kk_yaml_emitter_create"


### PR DESCRIPTION
previously we don't call kk_string_drop, because if we do it will make the yaml parser parse on freed string. I deliberately leaks the string just to see the parser work.

This PR fixes it, the yaml parser now borrow koka string. And guaranteed the string valid until the parser freed.